### PR TITLE
Manual OCR corrections

### DIFF
--- a/test-bed-ocr/1957/Ground-Truth/00000011.txt
+++ b/test-bed-ocr/1957/Ground-Truth/00000011.txt
@@ -1,5 +1,4 @@
-ANNUAL SACRED HARP SINGINGS
-9
+ANNUAL SACRED HARP SINGINGS 9
 Called to order by L. L. Welborn singing 145t, 426; Mrs. Irene Parker,
 189, 419; Jasper Harper, 167, 388; Mrs. Lola Jenkins, 411, 402; Mr. Ford, 187,
 151; Mrs. Ludie Lambert, 149, 120; Preston Warren, 71, 337; Mrs. O. H.
@@ -16,12 +15,12 @@ Johnnie Gaines, 35, 225; Charlie Creel, 374, 448t; Mrs. Elsie McCullar, 386,
 George Phillips.
 OTTO ALLRED, Chairman
 0. H. HANDLEY, Vice-Chairman
-1. M. HEATHERLY, Secretary
+I. M. HEATHERLY, Secretary
 Praco, Ala.
-*
+
 Macedonia Church Singing
 February 10, 1957
-House called to order by chairman singing, 348; Prayer by John Bai¬
+House called to order by chairman singing, 348; Prayer by John Bai-
 ley. Election of officers, Jim DeFoore, chairman, Lloyd Woods, vice-
 chairman and H. W. Tittle, secretary. Arranging Committee, Roy Mays,
 Elisha Duboise and Tommy Frederick, chairman singing 65, 59, 31b, 37b,
@@ -30,7 +29,7 @@ Leaders, Charlie Berry, 318, 441; Alex Godsey, 138, 203; Walter Wakefield,
 216; D. M. Aldridge, 454, 358; Floyd Davis, 349, 415; Shirley Butler, 273,
 212; Chairman, 400.
 Rest 10 minutes.
-Called to order by Vice-Chairman singing .172; Otto. Allred 422, 316;
+Called to order by Vice-Chairman singing 172; Otto Allred 422, 316;
 Bray Durr, 334, 100; Arthur Cain, 36, 45t; D. E. Griffin, 282, 388; Ann Woods,
 361, 269; D. O. Putman, 272, 283; Ozella, Chaffin, 192, 436; Nelson Butler,
 460, 426; Willodene Smitherman, 336; Elmer Conwell, 142, 183; Maggie Mc-
@@ -44,8 +43,8 @@ Marion Chaffin, 329, 301; Mrs. Nelson Butler, 294, 395; Remus Conant, 236,
 Rest 10 minutes.
 Called to order by Vice-Chairman singing 302; John Posey, 455, 377;
 Ila V. Glenn and L. E. Hamner, 440, 340; Bobby Aldridge, 421, 332; Fletcher
-Sission 215, 135; Myrtice Hood and Myrtice Thomas, 145, 343; Robert God¬
-sey and wife, 112, 137; Lola Mae Robinson and Susie Amos, 457, 408; Jes¬
+Sission 215, 135; Myrtice Hood and Myrtice Thomas, 145, 343; Robert God-
+sey and wife, 112, 137; Lola Mae Robinson and Susie Amos, 457, 408; Jes-
 sie Adams and wife, 205, 44; Wash Pugh, 146, 387; Chairman, 381, 403.
 J. H. DEFOORE, Chairman
 LLOYD WOOD, Vice-Chairman


### PR DESCRIPTION
Replaced `¬` with `-` in a few places. Corrected `1. M. Heatherly` to `I. M. Heatherly` for the second page. Specks in second paragraph of Macedonia singing caused some extra errant punctuation.