### PR TITLE
Manual OCR corrections

### DIFF
--- a/test-bed-ocr/1957/Ground-Truth/00000013.txt
+++ b/test-bed-ocr/1957/Ground-Truth/00000013.txt
@@ -6,9 +6,9 @@ Class called to order by Lloyd Wood singing, 284, 203; Susie Amos, 222,
 430; Miss Elene Aldridge, 153, 405; Floyd Frederick, 316, 217; Mrs. Ruby
 Conwell, 270, 208.
 One hour for lunch.
-Bro. Smith graced the table and there was plenty of dinner for every¬
+Bro. Smith graced the table and there was plenty of dinner for every-
 one.
-Class called to order by Chairman singing one song and then in¬
+Class called to order by Chairman singing one song and then in-
 troduced the pastor to the class, Rev. Patterson, and asked him to say
 what ever he would like to say about the singing. He said a lot of nice
 things to the class and gave us a hearty welcome and asked us to come
@@ -16,7 +16,7 @@ back next year at this time for another all-day singing.
 Next leader was Willie Baldy; Bert Smith, Estes Jackson, Jim De-
 foore, R. S. Black, Linda Amos, T. A. Baldy, Jenette Norris, Roy Mays,
 Jim Lee, J. H. Ballinger, Thornton White, Grady Harper, Mrs. Eva Bell
-Hyche, Willie Cantrell, Mrs. Willie A. Bonner, Floyd Davis. The Chair¬
+Hyche, Willie Cantrell, Mrs. Willie A. Bonner, Floyd Davis. The Chair-
 man sang several requests and called for announcements. The singing
 was announced for this church next year, the third Sunday in February,
 1958; and everyone invited to come back, and as secretary and part of the
@@ -46,4 +46,4 @@ Woodley, 282, 380; Ann Wood and Pat Butler, 460, 112; W. H. Chandler,
 269, 355; John Hocutt, 236, 193; G. S. Doss, 284, 286.
 One hour for lunch.
 Called to order by Lee Chambers, 280; Benny Capps, 377, 442; Preston
-Warren. 439. 386; L. O. Gilliland, 205, 435t.; Mrs. James Smitherman, 314;
+Warren, 439, 386; L. O. Gilliland, 205, 435t.; Mrs. James Smitherman, 314;


### PR DESCRIPTION
Just some corrections from `¬` to `-` and a couple of commas cut off in image thus interpreted as periods. I suspect no OCR engine could correctly identify the commas, but I changed them anyhow.