### PR TITLE
Manual OCR corrections

### DIFF
--- a/test-bed-ocr/1957/Ground-Truth/00000014.txt
+++ b/test-bed-ocr/1957/Ground-Truth/00000014.txt
@@ -10,13 +10,13 @@ rick, 299, 328; Demus Aldridge, 183, 455; Lee Wells, 383, 404; Geo. Phillips,
 Chairman, 46. Benediction by J. J. Akers.
 MRS. ALPHA PITTMAN, Secretary,
 Route One, Arley, Ala.
-o
+
 Beulah Primitive Baptist Church Singing
 Leeds, Ala. — March 3, 1957
 The Annual Sacred Harp singing on the First Sunday in March was
 opened by John M. Moore singing 30t, 56t, 32t; followed by prayer led by
 Carl Hughes after which the class organized for the day by electing John
-M. Moore, chairman, G. S. Doss, vice-chairman, and Leonard Morris, secre¬
+M. Moore, chairman, G. S. Doss, vice-chairman, and Leonard Morris, secre-
 tary, Andy Moore, E. Wall and Preston Warren, arranging committee.
 After the organization leaders was called who sang the songs following
 their names: M. E. Bowen, 78, 74; Homer Lambert, 391, 227; Mrs. Alpha
@@ -30,17 +30,17 @@ Arthur Bentley, 172, 436; A. E. Cagle, 186, 300; Mrs. Maud Quinn, 72t, 348b;
 J. T. Tittle, 240, 377; Herby Bailey, 446, 291; Ira James, 34t, 435b.
 Rest 10 minutes.
 George Phillips called the class to order and sang, 29t, 383; followed
-by R. H. Burnham, 45t, 460; Mrs. Mae Seymour, 327, 301; Mrs. Irene Par¬
+by R. H. Burnham, 45t, 460; Mrs. Mae Seymour, 327, 301; Mrs. Irene Par-
 ker, 234, 355; G. S. Doss, 189, 235; in memory of Pinson Moore.
 One hour for lunch.
 Preston Warren called the class to order and sang 48t, 147t; W. D,
 Holland,, 200; Kenny Dean, 300, 196; Hugh McGraw, 369, 250; Mrs. C. H.
-Gilliland, 18t, 273; W. B. Mathew, 169, 311; R. E. Denson, 211, 216; Ernes¬
+Gilliland, 18t, 273; W. B. Mathew, 169, 311; R. E. Denson, 211, 216; Ernes-
 tine Lambert, 444, 447; Judy McGraw, 84, 396; A. L. Parker, 430, 422; Lloyd
 Redding, 268, 442; Reece Hughes, 386, 367; V. C. Harvey, 299, 224.
 Rest 10 minutes.
 E. Wall sang 343; followed by C. H. Gilliland, 280, 292; J. A. Chandler,
 192, 455; A. L. Hanks, 290, 179; J. L. Edge, 195; Mrs. Carlene Griffin, 222,
-302; Mrs. Jeanett Tyner, 362, 440; Bufrey Dean, 426b, 94; Rufus Holley'
-212, 304; Mrs. Clelan Cobb, 434, 384; L. J. Cagle, 340, 215; Odell Cleveland'
-101b, 418; Herman Lambert, 441, 432; Mrs. Rosa Hughes, 411, 203- G S*
+302; Mrs. Jeanett Tyner, 362, 440; Bufrey Dean, 426b, 94; Rufus Holley,
+212, 304; Mrs. Clelan Cobb, 434, 384; L. J. Cagle, 340, 215; Odell Cleveland,
+101b, 418; Herman Lambert, 441, 432; Mrs. Rosa Hughes, 411, 203; G S.


### PR DESCRIPTION
Some corrections from `¬` to `-`. Punctuation at bottom right was wrong in 4–5 spots.