### PR TITLE
Manual OCR corrections

### DIFF
--- a/test-bed-ocr/1957/Ground-Truth/00000015.txt
+++ b/test-bed-ocr/1957/Ground-Truth/00000015.txt
@@ -1,5 +1,4 @@
-ANNUAL SACRED HARP SINGINGS
-13
+ANNUAL SACRED HARP SINGINGS 13
 Doss, 382; and George Phillips dismissed the congregation with prayer.
 To meet again the first Sunday in March, 1958, at the Beulah Primitive
 Baptist Church. Located 3 blocks north of the traffic light on Highway
@@ -24,7 +23,7 @@ Jim Defoor, 349, 240; Emmit Bennett, 220, 384; Howard McGuire, 454, 192;
 Myrtle Thomas, 280, 390; Jeannette Norris, 191, 234; Rufus Tidwell, 340,
 426b, H. M. Blackwell, 217, 218; Chairman 285t.
 One hour for lunch.
-Called to order by Dewey McCullar singing, 204, 34t; Jessie Adarrfs,
+Called to order by Dewey McCullar singing, 204, 34t; Jessie Adams,
 343b, 56t; Tom Harper, 456, 439; Elsie McCullar, 197, 430; Marion Chafin,
 224, 181; Marie Ryan, 132, 216; I. M. Heatherly, 455, 442; R. J. Godsey, 112,
 272; Fay Wakefield, 168, 328; Willie Rhodes, 298, 142; Susit Amos, 269, 428;
@@ -39,7 +38,7 @@ EMMIT WOODLEY, Chairman
 H. G. COLE, Vice-Chairman
 I. M. HEATHERLY, Secretary
 Praco, Ala.
-©
+
 Elvista Church, between Warrior and Trafford
 March 10, 1957
 House called to order at 10 a. m. by Mel Reid singing, 47t; Prayer by


### PR DESCRIPTION
Deleted extraneous character, corrected three letters misinterpreted because of stray line, page placed number on same line as header.